### PR TITLE
Configuration to save request/response json

### DIFF
--- a/app/models/voltron/notification.rb
+++ b/app/models/voltron/notification.rb
@@ -9,7 +9,7 @@ module Voltron
 
     before_validation :prepare
 
-    PERMITTED_ATTRIBUTES = [:to, :from]
+    PERMITTED_ATTRIBUTES = [:to, :from, :body]
 
     def email(subject, options={}, &block)
       # Get the remaining args as params, that will eventually become assigns in the mailer template

--- a/app/models/voltron/notification/email_notification.rb
+++ b/app/models/voltron/notification/email_notification.rb
@@ -115,8 +115,10 @@ class Voltron::Notification::EmailNotification < ActiveRecord::Base
       @created = true
       @mail_options = nil
       @delivery_method = nil
-      self.request_json = @request.to_json
-      self.response_json = @response.to_json
+      if Voltron.config.notify.store_requests
+        self.request_json = @request.to_json
+        self.response_json = @response.to_json
+      end
 
       # if use_queue?, meaning if this was sent via ActiveJob, we need to save ourself
       # since we got to here within after_create, meaning setting the attributes alone won't cut it

--- a/app/models/voltron/notification/sms_notification.rb
+++ b/app/models/voltron/notification/sms_notification.rb
@@ -121,8 +121,10 @@ class Voltron::Notification::SmsNotification < ActiveRecord::Base
       @created = true
       @job_options = nil
       @job_method = nil
-      self.request_json = @request.to_json
-      self.response_json = @response.to_json
+      if Voltron.config.notify.store_requests
+        self.request_json = @request.to_json
+        self.response_json = @response.to_json
+      end
       self.sid = response.first.try(:[], :sid)
       self.status = response.first.try(:[], :status) || 'unknown'
 

--- a/lib/generators/templates/db/migrate/create_voltron_notification_email_notifications.rb
+++ b/lib/generators/templates/db/migrate/create_voltron_notification_email_notifications.rb
@@ -4,6 +4,7 @@ class CreateVoltronNotificationEmailNotifications < ActiveRecord::Migration
       t.string :to
       t.string :from
       t.string :subject
+      t.text   :body
       t.string :template_path
       t.string :template_name
       t.string :mailer_class

--- a/lib/voltron/config/notify.rb
+++ b/lib/voltron/config/notify.rb
@@ -7,7 +7,7 @@ module Voltron
 
     class Notify
 
-      attr_accessor :use_queue
+      attr_accessor :use_queue, :store_requests
 
       # SMS config settings
       attr_accessor :sms_account_sid, :sms_auth_token, :sms_from
@@ -17,6 +17,7 @@ module Voltron
 
       def initialize
         @use_queue ||= false
+        @store_requests ||= true
         @email_from ||= 'no-reply@example.com'
         @default_mailer = Voltron::NotificationMailer
         @default_method = :notify

--- a/spec/railsapp/db/migrate/20160922200950_create_voltron_notification_email_notifications.rb
+++ b/spec/railsapp/db/migrate/20160922200950_create_voltron_notification_email_notifications.rb
@@ -4,6 +4,7 @@ class CreateVoltronNotificationEmailNotifications < ActiveRecord::Migration
       t.string :to
       t.string :from
       t.string :subject
+      t.text   :body
       t.string :template_path
       t.string :template_name
       t.string :mailer_class


### PR DESCRIPTION
- Ability to turn on/off request/response json saving. Request/Response jsons are taking much space in DB.
- Add body field to voltron_notification_email_notifications table.